### PR TITLE
Optimization results:

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -14,3 +14,5 @@ gradle-app.setting
 
 # # Work around https://youtrack.jetbrains.com/issue/IDEA-116898
 # gradle/wrapper/gradle-wrapper.properties
+/bin/
+/.apt_generated/

--- a/build.gradle
+++ b/build.gradle
@@ -13,6 +13,7 @@ repositories {
 }
 
 apply plugin: "java"
+apply plugin: "eclipse"
 
 wrapper {
 	gradleVersion = "4.10.3"
@@ -24,8 +25,10 @@ targetCompatibility = 1.8
 
 dependencies {
 	compileOnly 'org.projectlombok:lombok:1.18.4'
+	compile group: 'org.eclipse.jetty', name: 'jetty-client', version: '9.4.15.v20190215'
 	compile group: 'org.apache.commons', name: 'commons-collections4', version: '4.2'
-	apt 'org.projectlombok:lombok:1.18.4'
+	compile group: 'com.google.guava', name: 'guava', version: '23.0'
+	annotationProcessor 'org.projectlombok:lombok:1.18.4'
 }
 
 jar {

--- a/optimization.plan
+++ b/optimization.plan
@@ -1,0 +1,15 @@
+[V] Replace URL class with String as Cache Key. Result: Improved stream filter performance in 46 times (4600%).
+[V] Adjusted thread pool size: ThreadPoolExecutor(parallelism*6, parallelism*6. Result: Compensated network delays and improved collection Urls speed in 2.48 times (248%)
+[V] Change architecture from new Thread for each new http request -> to call NIO Http Client (Jetty) which use only several threads for huge amount of parallel requests.
+	Result: Improved parallel requests speed in 11.8 times (1180%). 
+[V] Cache replaced with Thread-safe Cache implementation and removed synchronized block. Result: in current configured thread count no difference detected.
+[V] Removed double checks (for example: HTTP_FILTER test remove because it repeat extractLinks RegExp checks.)
+[V] Added Links Prioritization logic using PriorityBlockingQueue -> External links has high priority to distribute the load on external sites from initial site (to avoid DDOS effect on initial site)
+[V] Move conversion WithoutAnchorAndQuery into extractLinks (logically solid actions).
+[V] Do not create empty links.txt file when 0 links extracted.
+
+
+Tested on URLS:
+http://www.hikorea.ru/en/auxpage_katalog-sajtov/
+http://cat.spbland.ru/cat_id/115/
+https://en.wikipedia.org/wiki/(486958)_2014_MU69

--- a/src/main/java/com/dell/jobot/FixedCacheUniquenessFilter.java
+++ b/src/main/java/com/dell/jobot/FixedCacheUniquenessFilter.java
@@ -1,24 +1,28 @@
 package com.dell.jobot;
 
-import org.apache.commons.collections4.map.LRUMap;
-
+import com.dell.jobot.monitor.PerformanceMonitor;
+import com.google.common.cache.CacheBuilder;
 import java.util.Map;
 import java.util.function.Predicate;
 
 public class FixedCacheUniquenessFilter<T>
 implements Predicate<T> {
 
-	private static final Object dummy = new Object();
+	private static final Object staticValue = new Object();
 	private final Map<T, Object> cache;
 
 	public FixedCacheUniquenessFilter(final int capacity) {
-		cache = new LRUMap<>(capacity);
+		// cache = new LRUMap<>(capacity);
+		this.cache = CacheBuilder.newBuilder().maximumSize(capacity).<T, Object>build().asMap();
 	}
 
 	@Override
 	public boolean test(final T v) {
-		synchronized(cache) {
-			return null == cache.putIfAbsent(v, dummy);
-		}
+		//synchronized(cache) {
+		boolean result = null == cache.putIfAbsent(v, staticValue);//return null == cache.putIfAbsent(v, staticValue);
+		//}
+		if (result)
+			PerformanceMonitor.trackUrlsCollected(cache.size());
+		return result;
 	}
 }

--- a/src/main/java/com/dell/jobot/HttpUrlProcessingTask.java
+++ b/src/main/java/com/dell/jobot/HttpUrlProcessingTask.java
@@ -1,95 +1,109 @@
 package com.dell.jobot;
 
+import lombok.EqualsAndHashCode;
 import lombok.Value;
 import lombok.val;
 
 import java.io.BufferedReader;
 import java.io.IOException;
+import java.io.InputStream;
 import java.io.InputStreamReader;
-import java.net.HttpURLConnection;
-import java.net.ProtocolException;
 import java.net.URL;
+import java.util.ArrayList;
 import java.util.HashSet;
-import java.util.Optional;
-
+import org.eclipse.jetty.client.api.Result;
+import org.eclipse.jetty.client.util.BufferingResponseListener;
+import com.dell.jobot.monitor.PerformanceMonitor;
 import static com.dell.jobot.HyperlinkUtil.extractLinks;
 
 @Value
-public class HttpUrlProcessingTask
-implements Runnable {
+@EqualsAndHashCode(callSuper=false)
+public class HttpUrlProcessingTask extends BufferingResponseListener
+implements Comparable<HttpUrlProcessingTask> {
 
 	private final HttpUrlStreamHandler handler;
 	private final URL url;
+	private final URL parent;
 
-	public HttpUrlProcessingTask(final HttpUrlStreamHandler handler, final URL url) {
+	public HttpUrlProcessingTask(final HttpUrlStreamHandler handler, final URL url,  final URL parent) {
 		this.handler = handler;
 		this.url = url;
+		this.parent = parent;
+	}
+	
+	/*
+	 * On Jetty HttpCliet request complete (Each onComplete() call HttpClient make in dedicated
+	 * Thread.)
+	 */
+	@Override
+	public void onComplete(Result result) {
+		PerformanceMonitor.trackUrlsRequestReceived();
+		handleResponseContent(getContentAsInputStream());
+	}
+
+	void handleResponseContent(final InputStream stream) {
+		System.out.print("."); // System.out.println("Downloading " + url + " ...");
+		try (val contentReader = new BufferedReader(new InputStreamReader(stream))) {
+			String line;
+			/*
+			 * Added 2 sets to separate internal an external links and put external to the top -> to
+			 * distribute the load on external sites and reduce it for the start site
+			 */
+			val internalLinkBuff = new HashSet<String>();
+			val externalLinkBuff = new HashSet<String>();
+			while (null != (line = contentReader.readLine())) {
+				extractLinks(url, line, internalLinkBuff, externalLinkBuff);
+			}
+			val resultUrlsList = new ArrayList<String>();
+			resultUrlsList.addAll(externalLinkBuff);
+			resultUrlsList.addAll(internalLinkBuff);
+			if (!resultUrlsList.isEmpty()) {
+				handler.handle(url, resultUrlsList.stream());
+			}
+		} catch (final IOException e) {
+			System.err.println("I/O failure while reading the content from the url: \"" + url + "\"");
+		} catch (final Throwable t) {
+			t.printStackTrace(System.err);
+		}
+	}
+
+	/*
+	 * Priority uses for sorting in queue -> External links has high priority to distribute the load
+	 * on external sites from initial site
+	 */
+	public int getPriority() {
+		if (this.parent == null)
+			return 2;
+		else {
+			if (this.parent.getHost().equals(this.url.getHost()))
+				return 1;
+			else {
+				if (findSecondLevelDomain(this.parent.getHost())
+						.equals(findSecondLevelDomain(this.url.getHost())))
+					return 2;
+				else
+					return 3;
+			}
+		}
+	}
+
+	private String findSecondLevelDomain(String host) {
+		val lastDot = host.lastIndexOf(".");
+		if (lastDot != -1) {
+			val secondDot = host.substring(0, lastDot).lastIndexOf(".");
+			if (secondDot != -1) {
+				return host.substring(secondDot + 1);
+			} else {
+				return host;
+			}
+		}
+		throw new AssertionError(
+				"Host exception host cannot contain less than one dot: [" + host + "]");
 	}
 
 	@Override
-	public void run() {
-		connect(url).ifPresent(this::handleConnection);
-	}
-
-	static Optional<HttpURLConnection> connect(final URL url) {
-		try {
-			return Optional.of((HttpURLConnection) url.openConnection());
-		} catch(final IOException e) {
-			System.err.println("Was unable to connect the server \"" + url.getHost() + ":" + url.getPort() + "\"");
-			return Optional.empty();
-		}
-	}
-
-	void handleConnection(final HttpURLConnection conn) {
-		sendRequest(conn);
-		handleResponse(conn);
-	}
-
-	static void sendRequest(final HttpURLConnection conn) {
-		try {
-			conn.setRequestMethod("GET");
-		} catch(final ProtocolException e) {
-			e.printStackTrace(System.err);
-		}
-		conn.setRequestProperty("User-Agent", "jobot");
-	}
-
-	void handleResponse(final HttpURLConnection conn) {
-		try {
-			val respCode = conn.getResponseCode();
-			if(respCode < 400) {
-				if(respCode >= 300) {
-					conn.setInstanceFollowRedirects(true);
-				}
-				val contentType = conn.getContentType();
-				if(contentType.startsWith("text")) {
-					handleResponseContent(conn);
-				} else {
-					System.out.println("Filtered by content type (" + contentType + "): " + url);
-				}
-			} else {
-				System.err.println("Response code " + respCode +" for: " + url);
-			}
-		} catch(final IOException e) {
-			System.err.println("I/O failure while reading the response from the url: \"" + url + "\"");
-		}
-	}
-
-	void handleResponseContent(final HttpURLConnection conn) {
-		System.out.println("Downloading " + url + " ...");
-		try(val contentReader = new BufferedReader(new InputStreamReader(conn.getInputStream()))) {
-			String line;
-			val linkBuff = new HashSet<String>();
-			while(null != (line = contentReader.readLine())) {
-				extractLinks(line, linkBuff);
-			}
-			if(!linkBuff.isEmpty()) {
-				handler.handle(url, linkBuff.stream());
-			}
-		} catch(final IOException e) {
-			System.err.println("I/O failure while reading the content from the url: \"" + url + "\"");
-		} catch(final Throwable t) {
-			t.printStackTrace(System.err);
-		}
+	public int compareTo(HttpUrlProcessingTask o) {
+		Integer.compare(this.getPriority(), o.getPriority());
+		return 0;
 	}
 }

--- a/src/main/java/com/dell/jobot/HttpUrlStreamHandler.java
+++ b/src/main/java/com/dell/jobot/HttpUrlStreamHandler.java
@@ -34,9 +34,9 @@ implements RawUrlStreamHandler {
 		this.urlsQueue = urlsQueue;
 	}
 	
-	private void addUrlsQueue(HttpUrlProcessingTask task) {
-		urlsQueue.add(task);
-		PerformanceMonitor.trackTasksSubmit(task);
+	private void addUrlToQueue(HttpUrlProcessingTask urlTask) {
+		urlsQueue.add(urlTask);
+		PerformanceMonitor.trackTasksSubmit(urlTask);
 	}
 
 	@Override
@@ -51,9 +51,10 @@ implements RawUrlStreamHandler {
 				/* Cleaned up redundant/double checks */
 				.map(UrlUtil::convertToUrl)
 				.filter(Optional::isPresent)
-				.map(Optional::get).filter(urlFilter)
+				.map(Optional::get)
+				.filter(urlFilter)
 				.map(url -> new HttpUrlProcessingTask(this, url, parent))
-				.peek(this::addUrlsQueue)
+				.peek(this::addUrlToQueue)
 				.map(HttpUrlProcessingTask::getUrl)
 				.collect(Collectors.toList());
 
@@ -68,8 +69,6 @@ implements RawUrlStreamHandler {
 			}
 			try (val linksFileWriter = Files.newBufferedWriter(outputPath, StandardOpenOption.CREATE,
 					StandardOpenOption.TRUNCATE_EXISTING)) {
-				/*.map(url -> new HttpUrlProcessingTask(this, url, parent))
-					.peek(this::submit)*/
 				urls.forEach(url -> {
 					try {
 						linksFileWriter.append(url.toString());

--- a/src/main/java/com/dell/jobot/HttpUrlStreamHandler.java
+++ b/src/main/java/com/dell/jobot/HttpUrlStreamHandler.java
@@ -9,60 +9,78 @@ import java.net.URL;
 import java.nio.file.Files;
 import java.nio.file.Paths;
 import java.nio.file.StandardOpenOption;
+import java.util.Arrays;
+import java.util.List;
 import java.util.Optional;
-import java.util.concurrent.ExecutorService;
+import java.util.Queue;
 import java.util.function.Predicate;
+import java.util.regex.Pattern;
+import java.util.stream.Collectors;
 import java.util.stream.Stream;
+import com.dell.jobot.monitor.PerformanceMonitor;
 
 public class HttpUrlStreamHandler
 implements RawUrlStreamHandler {
 
 	public static final String OUTPUT_DIR = System.getProperty("user.home") + File.separator + ".jobot";
 	public static final String LINKS_FILE_NAME = "links.txt";
+	private static final Pattern PATH_SPECIAL_SYMBOLS = Pattern.compile("[:]");
 
-	private final ExecutorService executor;
 	private final Predicate<URL> urlFilter;
+	private final Queue<HttpUrlProcessingTask> urlsQueue;
 
-	public HttpUrlStreamHandler(final ExecutorService executor, final Predicate<URL> urlFilter) {
-		this.executor = executor;
+	public HttpUrlStreamHandler(final Predicate<URL> urlFilter, final Queue<HttpUrlProcessingTask> urlsQueue) {
 		this.urlFilter = urlFilter;
+		this.urlsQueue = urlsQueue;
+	}
+	
+	private void addUrlsQueue(HttpUrlProcessingTask task) {
+		urlsQueue.add(task);
+		PerformanceMonitor.trackTasksSubmit(task);
+	}
+
+	@Override
+	public void handle(final URL parent, final @NonNull String[] urls) {
+		handle(parent, Arrays.stream(urls).filter(HyperlinkUtil.HTTP_FILTER)
+				.map(HyperlinkUtil::cutAnchorAndQuery));
 	}
 
 	@Override
 	public void handle(final URL parent, final @NonNull Stream<String> inStream) {
-		val outputPath = parent == null ?
-			Paths.get(OUTPUT_DIR, LINKS_FILE_NAME) :
-			Paths.get(OUTPUT_DIR, parent.getHost(), parent.getPath(), LINKS_FILE_NAME);
-		try {
-			Files.createDirectories(outputPath.getParent());
-		} catch(final IOException e) {
-			e.printStackTrace(System.err);
-		}
-		try(
-			val linksFileWriter = Files.newBufferedWriter(
-				outputPath, StandardOpenOption.CREATE, StandardOpenOption.TRUNCATE_EXISTING
-			)
-		) {
-			inStream
-				.map(UrlUtil::convertToUrlWithoutAnchorAndQuery)
+		List<URL> urls = inStream
+				/* Cleaned up redundant/double checks */
+				.map(UrlUtil::convertToUrl)
 				.filter(Optional::isPresent)
-				.map(Optional::get)
-				.filter(urlFilter)
-				.map(url -> new HttpUrlProcessingTask(this, url))
-				.peek(executor::submit)
+				.map(Optional::get).filter(urlFilter)
+				.map(url -> new HttpUrlProcessingTask(this, url, parent))
+				.peek(this::addUrlsQueue)
 				.map(HttpUrlProcessingTask::getUrl)
-				.forEach(
-					url -> {
-						try {
-							linksFileWriter.append(url.toString());
-							linksFileWriter.newLine();
-						} catch(final IOException e) {
-							e.printStackTrace(System.err);
-						}
+				.collect(Collectors.toList());
+
+		if (urls.size() > 0) {
+			val outputPath = parent == null ? Paths.get(OUTPUT_DIR, LINKS_FILE_NAME)
+					: Paths.get(OUTPUT_DIR, parent.getHost(),
+							PATH_SPECIAL_SYMBOLS.matcher(parent.getPath()).replaceAll("_"), LINKS_FILE_NAME);
+			try {
+				Files.createDirectories(outputPath.getParent());
+			} catch (final IOException e) {
+				e.printStackTrace(System.err);
+			}
+			try (val linksFileWriter = Files.newBufferedWriter(outputPath, StandardOpenOption.CREATE,
+					StandardOpenOption.TRUNCATE_EXISTING)) {
+				/*.map(url -> new HttpUrlProcessingTask(this, url, parent))
+					.peek(this::submit)*/
+				urls.forEach(url -> {
+					try {
+						linksFileWriter.append(url.toString());
+						linksFileWriter.newLine();
+					} catch (final IOException e) {
+						e.printStackTrace(System.err);
 					}
-				);
-		} catch(final IOException e) {
-			e.printStackTrace(System.err);
+				});
+			} catch (final IOException e) {
+				e.printStackTrace(System.err);
+			}
 		}
 	}
 }

--- a/src/main/java/com/dell/jobot/HyperlinkUtil.java
+++ b/src/main/java/com/dell/jobot/HyperlinkUtil.java
@@ -2,21 +2,52 @@ package com.dell.jobot;
 
 import lombok.NonNull;
 import lombok.val;
-
+import java.net.URL;
 import java.util.Collection;
+import java.util.function.Predicate;
 import java.util.regex.Pattern;
 
 public interface HyperlinkUtil {
 
 	String GROUP_NAME_VALUE = "value";
+	String PROTOCOL = "http://";
+	int PROTOCOL_LENGTH = PROTOCOL.length();
+	Pattern PATTERN_HREF_VALUE = Pattern.compile("href=\"(?<" + GROUP_NAME_VALUE + ">"+PROTOCOL+"[^\"]{8,256})\"");
 
-	Pattern PATTERN_HREF_VALUE = Pattern.compile("href=\"(?<" + GROUP_NAME_VALUE + ">http://[\\S^\"]{8,256})\"");
-
-	static void extractLinks(final @NonNull String text, final @NonNull Collection<String> dstBuff) {
+	static void extractLinks(final @NonNull URL parentUrl, final @NonNull String text, final @NonNull Collection<String> internalUrlsBuff, final @NonNull Collection<String> exterbalUrlsBuff) {
 		val matcher = PATTERN_HREF_VALUE.matcher(text);
-		while(matcher.find()) {
-			val url = matcher.group(GROUP_NAME_VALUE);
-			dstBuff.add(url);
+		while (matcher.find()) {
+			String url = matcher.group(GROUP_NAME_VALUE);
+
+			url = cutAnchorAndQuery(url);
+
+			switch (url.substring(url.length() - 4).toLowerCase()) {
+				case ".jpg":
+				case ".png":
+				case ".flv":
+				case ".pdf":
+				case ".zip":
+				case ".gif":
+				case ".ico":
+					continue;
+			}
+
+			if (url.indexOf(parentUrl.getHost().toString()) == PROTOCOL_LENGTH)
+				internalUrlsBuff.add(url);
+			else
+				exterbalUrlsBuff.add(url);
 		}
 	}
+
+	static String cutAnchorAndQuery(@NonNull String urlString) {
+		/* Moved from UrlUtils.java here - more right place */
+		if (urlString.contains("#"))
+			urlString = urlString.substring(0, urlString.indexOf("#"));
+		if (urlString.contains("?"))
+			urlString = urlString.substring(0, urlString.indexOf("?"));
+
+		return urlString;
+	}
+
+	Predicate<String> HTTP_FILTER = url -> url.indexOf("http://") == 0;
 }

--- a/src/main/java/com/dell/jobot/RawUrlStreamHandler.java
+++ b/src/main/java/com/dell/jobot/RawUrlStreamHandler.java
@@ -12,4 +12,10 @@ public interface RawUrlStreamHandler {
 	 @param inStream The stream of the raw URLs which should be converted, filtered and handled
 	 */
 	void handle(final URL parent, final @NonNull Stream<String> inStream);
+	
+	/**
+	 @param parent The origin URL, may be null
+	 @param urls Array of raw URLs which should be converted, filtered and handled
+	 */
+	void handle(final URL parent, final @NonNull String[] urls);
 }

--- a/src/main/java/com/dell/jobot/UrlUtil.java
+++ b/src/main/java/com/dell/jobot/UrlUtil.java
@@ -5,20 +5,20 @@ import lombok.NonNull;
 import java.net.MalformedURLException;
 import java.net.URL;
 import java.util.Optional;
-import java.util.function.Predicate;
 
 public interface UrlUtil {
 
-	static Optional<URL> convertToUrlWithoutAnchorAndQuery(final @NonNull String raw) {
-		String t = raw;
-		if(t.contains("#")) {
-			t = t.substring(0, t.indexOf("#"));
-		}
-		if(t.contains("?")) {
-			t = t.substring(0, t.indexOf("?"));
-		}
+	static Optional<URL> convertToUrl(final @NonNull String raw) {
+		/* Moved to HyperlinkUtil.java */
+		//String t = raw;
+		//if(t.contains("#")) {
+		//	t = t.substring(0, t.indexOf("#"));
+		//}
+		//if(t.contains("?")) {
+		//	t = t.substring(0, t.indexOf("?"));
+		//}
 		try {
-			return Optional.of(new URL(t));
+			return Optional.of(new URL(raw));
 		} catch(final MalformedURLException e) {
 			System.err.println("Failed to convert \"" + raw + "\" to URL");
 			return Optional.empty();
@@ -27,5 +27,6 @@ public interface UrlUtil {
 		}
 	}
 
-	Predicate<URL> HTTP_FILTER = url -> url.getProtocol().startsWith("http");
+	/* Removed as duplicate check */
+	//Predicate<URL> HTTP_FILTER = url -> url.getProtocol().equals("http");
 }

--- a/src/main/java/com/dell/jobot/monitor/PerformanceMonitor.java
+++ b/src/main/java/com/dell/jobot/monitor/PerformanceMonitor.java
@@ -6,7 +6,7 @@ import com.dell.jobot.HttpUrlProcessingTask;
 
 public class PerformanceMonitor {
 	private static final int STEP = 1000;
-	private static final int REUESTS_STEP = 100;
+	private static final int REQUESTS_STEP = 100;
 	private static final AtomicLong startTime = new AtomicLong(System.currentTimeMillis());
 	private static final AtomicLong countFromLastTime = new AtomicLong(0);
 	private static final AtomicLong timeSum = new AtomicLong(0L);
@@ -20,7 +20,7 @@ public class PerformanceMonitor {
 			countFromLastTime.set(0);
 			long currentTimeSum = timeSum.addAndGet(result);
 			int currentSteps = steps.addAndGet(1);
-			System.err.println("\n>>>>>>> [ADD " + STEP + " Urls takes]: " + result + "ms Avg: "
+			System.err.println("\n>>>>>>> [Added " + STEP + " new links, takes]: " + result + "ms Avg: "
 					+ currentTimeSum / currentSteps + "ms");
 		}
 	}
@@ -28,13 +28,13 @@ public class PerformanceMonitor {
 	public static final void trackUrlsCollected(int count) {
 		int size;
 		if ((size = count) % STEP == 0)
-			System.err.println("\n>>>>>>> [Urls Collected]: " + size + " urls");
+			System.err.println("\n>>>>>>> [Total links Collected]: " + size + " urls");
 	}
 
 	public static final void trackUrlsRequestReceived() {
 		long requests;
-		if ((requests = completedRequests.incrementAndGet()) % REUESTS_STEP == 0) {
-			System.err.println("\n>>>>>>> [" + REUESTS_STEP + " Request completed]: " + requests);
+		if ((requests = completedRequests.incrementAndGet()) % REQUESTS_STEP == 0) {
+			System.err.println("\n>>>>>>> [Requests completed]: " + requests);
 		}
 	}
 }

--- a/src/main/java/com/dell/jobot/monitor/PerformanceMonitor.java
+++ b/src/main/java/com/dell/jobot/monitor/PerformanceMonitor.java
@@ -1,0 +1,40 @@
+package com.dell.jobot.monitor;
+
+import java.util.concurrent.atomic.AtomicInteger;
+import java.util.concurrent.atomic.AtomicLong;
+import com.dell.jobot.HttpUrlProcessingTask;
+
+public class PerformanceMonitor {
+	private static final int STEP = 1000;
+	private static final int REUESTS_STEP = 100;
+	private static final AtomicLong startTime = new AtomicLong(System.currentTimeMillis());
+	private static final AtomicLong countFromLastTime = new AtomicLong(0);
+	private static final AtomicLong timeSum = new AtomicLong(0L);
+	private static final AtomicInteger steps = new AtomicInteger(0);
+	private static final AtomicLong completedRequests = new AtomicLong(0L);
+
+	public static final void trackTasksSubmit(HttpUrlProcessingTask task) {
+		if (countFromLastTime.incrementAndGet() % STEP == 0) {
+			Long result = System.currentTimeMillis() - startTime.get();
+			startTime.set(System.currentTimeMillis());
+			countFromLastTime.set(0);
+			long currentTimeSum = timeSum.addAndGet(result);
+			int currentSteps = steps.addAndGet(1);
+			System.err.println("\n>>>>>>> [ADD " + STEP + " Urls takes]: " + result + "ms Avg: "
+					+ currentTimeSum / currentSteps + "ms");
+		}
+	}
+
+	public static final void trackUrlsCollected(int count) {
+		int size;
+		if ((size = count) % STEP == 0)
+			System.err.println("\n>>>>>>> [Urls Collected]: " + size + " urls");
+	}
+
+	public static final void trackUrlsRequestReceived() {
+		long requests;
+		if ((requests = completedRequests.incrementAndGet()) % REUESTS_STEP == 0) {
+			System.err.println("\n>>>>>>> [" + REUESTS_STEP + " Request completed]: " + requests);
+		}
+	}
+}


### PR DESCRIPTION
Results:

1) Replace URL class with String as Cache Key. Result: Improved stream filter performance in 46 times (4600%).
2) Adjusted thread pool size: ThreadPoolExecutor(parallelism*6, parallelism*6. Result: Compensated network delays and improved collection Urls speed in 2.48 times (248%)
3) Change architecture from new Thread for each new http request -> to call NIO Http Client (Jetty) which use only several threads for huge amount of parallel requests.
	Result: Improved parallel requests speed in 11.8 times (1180%). 
4) Cache replaced with Thread-safe Cache implementation and removed synchronized block. Result: in current configured thread count no difference detected.
5) Removed double checks (for example: HTTP_FILTER test remove because it repeat extractLinks RegExp checks.)
6) Added Links Prioritization logic using PriorityBlockingQueue -> External links has high priority to distribute the load on external sites from initial site (to avoid DDOS effect on initial site)
7) Move conversion WithoutAnchorAndQuery into extractLinks (logically solid actions).
8) Do not create empty links.txt file when 0 links extracted.


Tested on URLS:
http://www.hikorea.ru/en/auxpage_katalog-sajtov/
http://cat.spbland.ru/cat_id/115/
https://en.wikipedia.org/wiki/(486958)_2014_MU69